### PR TITLE
Bugfix: Security Group Tag

### DIFF
--- a/_posts/2023-03-08-aws-kubernetes-with-efs.md
+++ b/_posts/2023-03-08-aws-kubernetes-with-efs.md
@@ -99,7 +99,7 @@ And add it to the cluster by finding the `eks_managed_node_group_defaults` in th
 ```tf
   eks_managed_node_group_defaults = {
     instance_types = [var.instance_size]
-    vpc_security_group_ids = [aws_security_group.eks.id]
+    vpc_security_group_ids = [aws_security_group.efs.id]
   }
 ```
 


### PR DESCRIPTION
Hey Andrew,
thanks for your nice writeup of getting efs working with EKS!
If I'm not mistaken there's a little typo in your sample code, instead of `aws_security_group.eks.id` it should be `aws_security_group.efs.id`, since it should reference the security group resource `efs`.

Best Regards, Anton